### PR TITLE
It seems docker cannot go 'up' in folders, only down. That's why we just...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.4
+RUN mkdir /opt/gitmostwanted
+VOLUME ["/opt/gitmostwanted"]
+WORKDIR /opt/gitmostwanted
+ADD requirements.txt /opt/gitmostwanted/
+RUN pip install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ gitmostwanted:
   ports:
     - "5000:5000"
   volumes:
-    - .:/src
+    - ./gitmostwanted:/opt/gitmostwanted

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,0 @@
-FROM python:3.4
-WORKDIR /src
-RUN pip install -r requirements.txt


### PR DESCRIPTION
... put all the docker configs in the root directory.